### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-core": "~1.0",
-    "onelogin/php-saml":    "4.1.0"
+    "php":                  "^8.3",
+    "laravel/helpers":      "^1.8",
+    "dreamfactory/df-core": "~1.0.4",
+    "onelogin/php-saml":    "^4.1"
+  },
+  "require-dev": {
+    "laravel/framework":    "^13.7",
+    "mockery/mockery":      "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit":      "^11.5.3",
+    "orchestra/testbench":  "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   "prefer-stable": true,
   "require":     {
     "dreamfactory/df-core": "~1.0",
-    "onelogin/php-saml":    "4.1.0"
+    "onelogin/php-saml":    "^4.3.1"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Resources/Metadata.php
+++ b/src/Resources/Metadata.php
@@ -17,10 +17,19 @@ class Metadata extends BaseSamlResource
      */
     protected function handleGET()
     {
+        // Check if the user is authenticated
         if (!SessionUtilities::isAuthenticated()) {
-            return ResponseFactory::sendException(new BadRequestException(
-                "No session token (JWT) provided. Please provide a valid JWT using X-DreamFactory-Session-Token request header or 'session_token' url query parameter."
-            ));
+            // Return a JSON response with the appropriate headers
+            return ResponseFactory::create(
+                [
+                    'error' => [
+                        'code' => 400,
+                        'message' => "No session token (JWT) provided. Please provide a valid JWT using X-DreamFactory-Session-Token request header or 'session_token' url query parameter."
+                    ]
+                ],
+                'application/json', // Set content-type to JSON
+                400 // HTTP status code
+            );
         }
         /** @var SAML $service */
         $service = $this->getParent();

--- a/src/Resources/Metadata.php
+++ b/src/Resources/Metadata.php
@@ -2,9 +2,11 @@
 
 namespace DreamFactory\Core\Saml\Resources;
 
+use DreamFactory\Core\Exceptions\BadRequestException;
 use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use DreamFactory\Core\Saml\Services\SAML;
 use DreamFactory\Core\Utility\ResponseFactory;
+use DreamFactory\Core\Utility\Session as SessionUtilities;
 
 class Metadata extends BaseSamlResource
 {
@@ -15,6 +17,11 @@ class Metadata extends BaseSamlResource
      */
     protected function handleGET()
     {
+        if (!SessionUtilities::isAuthenticated()) {
+            return ResponseFactory::sendException(new BadRequestException(
+                "No session token (JWT) provided. Please provide a valid JWT using X-DreamFactory-Session-Token request header or 'session_token' url query parameter."
+            ));
+        }
         /** @var SAML $service */
         $service = $this->getParent();
         $settings = $service->getAuth()->getSettings();


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
